### PR TITLE
Expose AWSDeploy plugin lifecycles

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -34,6 +34,29 @@ class AwsDeploy {
       mergeIamTemplates
     );
 
+    this.commands = {
+      awsDeploy: {
+        // We declare the uppermost command as entrypoint because the AWSDeploy
+        // plugin does not expose any CLI commands.
+        type: 'entrypoint',
+        commands: {
+          build: {
+            lifecycleEvents: [
+              'prepare',
+            ],
+          },
+          deploy: {
+            lifecycleEvents: [
+              'prepare',
+              'uploadArtifacts',
+              'updateStack',
+              'cleanup',
+            ],
+          },
+        },
+      },
+    };
+
     this.hooks = {
       'before:deploy:initialize': () => BbPromise.bind(this)
         .then(this.validate),
@@ -48,15 +71,30 @@ class AwsDeploy {
       'before:deploy:compileFunctions': () => BbPromise.bind(this)
         .then(this.generateArtifactDirectoryName),
 
-      'deploy:deploy': () => BbPromise.bind(this)
-        .then(this.mergeCustomProviderResources)
-        .then(this.setBucketName)
-        .then(this.uploadArtifacts)
-        .then(this.updateStack)
-        .then(this.cleanupS3Bucket)
+      // The deploy spawns the internal build and deploy lifecycle
+      'deploy:deploy': () => this.serverless.pluginManager.spawn(['awsDeploy', 'build'])
+        .then(() => this.serverless.pluginManager.spawn(['awsDeploy', 'deploy']))
         .then(() => {
           if (this.options.noDeploy) this.serverless.cli.log('Did not deploy due to --noDeploy');
         }),
+
+      'awsDeploy:build:prepare': () => BbPromise.bind(this)
+        .then(this.validate)
+        .then(this.mergeCustomProviderResources),
+
+      'awsDeploy:deploy:prepare': () => BbPromise.bind(this)
+        .then(this.validate),
+
+      'awsDeploy:deploy:uploadArtifacts': () => BbPromise.bind(this)
+        .then(this.setBucketName)
+        .then(this.uploadArtifacts),
+
+      'awsDeploy:deploy:updateStack': () => BbPromise.bind(this)
+        .then(this.updateStack),
+
+      'awsDeploy:deploy:cleanup': () => BbPromise.bind(this)
+        .then(this.cleanupS3Bucket),
+
     };
   }
 }


### PR DESCRIPTION
Expose the AWSDeploy's lifecycle as real SLS lifecycle events.
Uses the new spawn() PluginManager method.
